### PR TITLE
audioCtx botones y noise

### DIFF
--- a/html/js/random-noise-processor.js
+++ b/html/js/random-noise-processor.js
@@ -1,0 +1,14 @@
+// random-noise-processor.js
+class RandomNoiseProcessor extends AudioWorkletProcessor {
+  process (inputs, outputs, parameters) {
+    const output = outputs[0]
+    output.forEach(channel => {
+      for (let i = 0; i < channel.length; i++) {
+        channel[i] = Math.random() * 2 - 1
+      }
+    })
+    return true
+  }
+}
+
+registerProcessor('random-noise-processor', RandomNoiseProcessor)

--- a/html/js/sonido.js
+++ b/html/js/sonido.js
@@ -1,0 +1,48 @@
+var AudioContext = window.AudioContext || window.webkitAudioContext; // esto será importante ? 
+audioCtx = new AudioContext()
+
+let randomNoiseNode;
+
+const activar = document.getElementById( 'activar' );
+activar.addEventListener( 'click', init );
+
+const desactivar = document.getElementById( 'desactivar' );
+desactivar.addEventListener( 'click', suspend );
+
+const reproducirRuido = document.getElementById( 'reproducirRuido' );
+reproducirRuido.addEventListener( 'click', reproducirRuidoFunc );
+
+const detenerRuido = document.getElementById( 'detenerRuido' );
+detenerRuido.addEventListener( 'click', detenerRuidoFunc );
+
+function init(){
+    // audioCtx = new AudioContext();
+
+    if(audioCtx.state === "suspended"){
+	audioCtx.resume();
+	console.log("iniciar"); 
+    }
+   
+    start();     
+}
+
+async function start(){
+    await audioCtx.audioWorklet.addModule('js/random-noise-processor.js');
+    randomNoiseNode = new AudioWorkletNode(audioCtx, 'random-noise-processor');
+    // randomNoiseNode.connect(audioCtx.destination);
+}
+
+function suspend(){
+    audioCtx.suspend();
+    console.log("suspender"); 
+}
+
+function reproducirRuidoFunc(){
+    randomNoiseNode.connect(audioCtx.destination);
+    console.log("reproducirRuido"); 
+}
+
+function detenerRuidoFunc(){
+    randomNoiseNode.disconnect(audioCtx.destination);
+    console.log("detener ruido"); 
+}

--- a/html/sonido.html
+++ b/html/sonido.html
@@ -17,9 +17,17 @@
         
         <section>
             <h1>Sonido</h1>
+	    <p>En algunos navegadores como chorme/chromium es necesario iniciar el audio con un gesto del usuario. Para este fin se puede usar un botón<p>
+	    <button type="button" id="activar">Activar sonido</button>
+	    <button type="button" id="desactivar">Desactivar sonido</button>
+	    <h2>Ruido blanco</h2>
+	    <button type="button" id="reproducirRuido">Reproducir</button>
+	    <button type="button" id="detenerRuido">Detener</button>
             <p>Acceder cámara</p>
             <p>Acceder micrófono</p>
         </section>
+
+	<script src="js/sonido.js"></script>
         
         <footer>
             @ SPTM 2023


### PR DESCRIPTION
Agregué un script con AudioContext, pienso que es el primer paso para activar algunas funcionales de audio
Agregué botones, estos no estaban establecidos en la lista de tareas pero pienso que puede ser importante para iniciar el audio context sin problemas (al menos en mi  caso así tengo que trabajar, algunas cosas como chrome requieren un gesto del usuario para inicializar el audio). Pienso que en el futuro esto podría tener toggles o cosas más trabajadas desde el css
Hay otro par de botones que activan y desactivan la conexión de un primer audioworklet que genera ruido blanco. Pienso que ese audioworklet puede ser la plantilla para trabajar otros módulos ( por ejemplo, a partir de ahí, deducir la sinusoide)
Finalmente fue necesario servir la página para que pudiera funcionar, en mi caso utilicé http-server . 
De otra manera, no es posible inicializar el audio a causa de Cors Policy. 