### PR TITLE
secuencia sencilla y muestra

### DIFF
--- a/audioSetup.js
+++ b/audioSetup.js
@@ -149,13 +149,12 @@ function Sine(aCtx){
 
 // Muestra y secuencia
 
-function Sample (aCtx, audioFile, aT){ // aquí hace falta poner la secuencia, audiofile está en html 
+function Sample (aCtx, audioFile){ // aquí hace falta poner la secuencia, audiofile está en html 
 
     self = this; 
     self.audioFile = audioFile;
 
     self.audioCtx = aCtx;
-    self.tempo = aT;
     
     // self.startTime = self.audioCtx.currentTime; // para medir
 
@@ -164,8 +163,17 @@ function Sample (aCtx, audioFile, aT){ // aquí hace falta poner la secuencia, a
     // separar load al menos para conceptualmente tener claro que primero se tiene que cargar el archivo. Esto sucede en cada evento
     // self.source;
 
-    self.buffer = 0; 
+    self.buffer = 0;
 
+    self.futureTickTime = self.audioCtx.currentTime,
+    self.counter = 1,
+    self.tempo = 120,
+    self.secondsPerBeat = 60 / self.tempo,
+    self.counterTimeValue = (self.secondsPerBeat / 4),
+    self.timerID = undefined,
+    self.isPlaying = false;
+    self.seq = [0, 0, 0, 0, 0, 0, 0, 0]; 
+    
     self.load = function(){
 
 	self.reader = new FileReader();
@@ -173,11 +181,17 @@ function Sample (aCtx, audioFile, aT){ // aquí hace falta poner la secuencia, a
 	    // self.audioCtx = aCtx;
 	    // console.log(self.audioCtx); 
 	    self.audioCtx.decodeAudioData(ev.target.result).then(function (buffer) {
-		self.source = self.audioCtx.createBufferSource()
-		self.source.buffer = buffer;
-		self.source.connect(self.audioCtx.destination) // Pregunta: una vez que termina, también se desconecta? 
-		self.source.start(0) // no es necesario reproducirlo aqui
-		console.log("sample"); 
+		//self.source = self.audioCtx.createBufferSource()
+		//self.source.buffer = buffer; // este estaba antes, ahora solamente queremos que se guarde
+		self.buffer = buffer; 
+		//self.source.connect(self.audioCtx.destination) // Pregunta: una vez que termina, también se desconecta? 
+		//self.source.start() // no es necesario reproducirlo aqui
+		console.log("sample");
+		// console.log(self.buffer);
+		self.counter = 0;
+		self.futureTickTime = self.audioCtx.currentTime;
+		self.scheduler(); 
+   
 	    })
 	}
 
@@ -185,7 +199,54 @@ function Sample (aCtx, audioFile, aT){ // aquí hace falta poner la secuencia, a
 	// aquí se reproduce la secuencia 
     }
 
-   
+    self.load();
+    
+    self.playSource = function(time){
+	console.log("algo"); 
+	self.source = self.audioCtx.createBufferSource();
+	self.source.connect(self.audioCtx.destination);
+	self.source.buffer = self.buffer;
+	self.source.start(self.audioCtx.currentTime + time);
+    }
+
+    self.schedule = function(time){
+	if(self.seq[self.counter] == 1){
+	    self.playSource(time);
+	    console.log("otro algo"); 
+	}
+    }
+
+    self.playTick = function() {
+	console.log(self.counter);
+	self.secondsPerBeat = 60 / self.tempo;
+	self.counterTimeValue = (self.secondsPerBeat / 1);
+	self.counter += 1;
+	self.futureTickTime += self.counterTimeValue;
+	if(self.counter == self.seq.length){
+	    self.counter = 0; 
+	}
+
+    }
+
+    
+    self.scheduler = function() {
+	if (self.futureTickTime < self.audioCtx.currentTime + 0.1) {
+            self.schedule(self.futureTickTime - self.audioCtx.currentTime);
+            self.playTick();
+	}
+
+	self.timerID = setTimeout(self.scheduler, 0);
+    }
+
+    self.sequence = function(seq){
+	self.seq = seq; 
+    }
+
+    self.stop = function(){
+	        clearTimeout(timerID);
+    }
+
+    // console.log(self.buffer); 
     // self.load(); // esto es mandatory 
    
 }

--- a/index.html
+++ b/index.html
@@ -126,13 +126,14 @@
       </div>
       <div class="separador">
         <h2 for="header_muestras">Múltiples muestras en un arreglo</h2>
-        <p for="desc_muestras">Ejemplo para relacionar carga y reproducción de archivos locales.</p>
+        <p for="desc_muestras">Ejemplo para relacionar carga y reproducción de archivos locales. Por el momento no pueden coexistir, como que se cancelan, el secuenciador está dentro del mismo módulo de audio</p>
         <div>
           <input id="audio_file1" type="file" accept="audio/*" title="Cargar archivo" />
         </div>
         <div>
           <input id="audio_file2" type="file" accept="audio/*" title="Cargar archivo" />
-        </div>
+        </div> 
+	<button type="button" id="detenerSeq" class="botones-sonido">Detener secuencia</button>
         <!--Necesitamos poner por aquí una caja de texto para escribir el código para live codear-->
       </div>
       <div class="separador">

--- a/inicio.js
+++ b/inicio.js
@@ -12,6 +12,7 @@ let a = new AudioSetup; // checar si esto no se contradice con algunas as que ap
 let sine, noise; 
 let parent =  document.querySelector('#editor')
 let editor = new EditorParser({ noise,sine, parent });
+let aF1; 
 
 const activar = document.getElementById( 'activar');
 activar.addEventListener('click', a.initAudio ); // init audio también inicializa el mic, ver si esto se puede quitar 
@@ -75,11 +76,12 @@ const audioFile1 = document.getElementById('audio_file1');
 const audioFile2 = document.getElementById( 'audio_file2');
 
 audioFile1.onchange = function () {
-    let aF1 = new Sample(a.audioCtx, audioFile1);
-    aF1.load(); 
+    aF1 = new Sample(a.audioCtx, audioFile1);
+    aF1.load(a.audioCtx, audioFile1); 
+    let seq = [1, 0, 1, 0, 1, 0, 1, 0]; 
+    aF1.sequence(seq); 
 }
 
 audioFile2.onchange = function () {
-    let aF2 = new Sample(a.audioCtx, audioFile2);
-    aF2.load(); 
+    let aF2 = new Sample(a.audioCtx, audioFile2); 
 }


### PR DESCRIPTION
Logré generar una secuencia, tuve que seguir más o menos este tutorial:

https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques#playing_the_audio_in_time

Estaría bueno revisar el que compartió @holomorfo, la verdad es que me costó trabajo entenderle y por eso ya no exploré esa opción. 

Hice unas variaciones para que el ciclo total de posibles valores de la secuencia se ajustara al tamaño de una secuencia que puede ser guardara y recorrida como un arreglo. Me pareció que esta aproximación podría ser similar a la visualización de pasos en un secuenciador ( donde 0 o una caja vacía no detona un sonido y donde 1 o una caja tachada detona sonido). Ej: 

 let seq = [1, 0, 1, 0, 1, 0, 0, 0] ( aparece al final de inicio.js) 

La secuencia está asociada a un tempo, no he probado cambiarlo sobre la marcha. 
Me decidí por esta sintaxis ya que es similar a las secuencias que se pueden utilizar con JitLib y Pseq 
Por el momento solamente es posible elegir un sample, cuando se trata de cargar otro, automáticamente sustituye al anterior. No he podido encontrar solución a esto. 
Otro asunto que queda pendiente ( y que puede ser solución para lo anterior ) es que seguramente hay que independizar el reloj general del secuenciador y en todo caso, ver si es posible generar distintos relojes para cada secuencia. Entonces pienso que podría existir un módulo adicional de "control" que arrancara un reloj y que los sintetizadores secuenciados pudieran adscribirse a él para no desfasarse ( pero que también pudiera tener la opción de desfase)
Finalmente podríamos tener variaciones de ganancia para darle variación de volumen a la secuencia ( y que no solamente fuera 0 o 1). 