### PR TITLE
generación y parsing de ritmos euclidianos

### DIFF
--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -6,8 +6,13 @@ const tutorialString = `// Presiona ctrl+enter para correr la linea donde esta e
 c a e
 a2 b2 e2 g2
 a4 b4 c4 d4 e4
-// el punto detiene la ultima secuencia reproducida
+// Ritmos euclidianos
+c4(3,8)
+g8(5,12)
+
+// El punto detiene la ultima secuencia reproducida
 .
+
 // Falta implementar los siguientes
 c
 cis

--- a/src/traducciones/sptm-live/conditionsCheck.js
+++ b/src/traducciones/sptm-live/conditionsCheck.js
@@ -1,6 +1,9 @@
+const bjorklund = require('../../../static/js/bjorklund')
+
 const regex = {
   lilyNote: /^([abcdefg])(es|is)?(\'+|\,+)?(\d)?$/m,
-  lilyNoteMulti: /^(([abcdefg])(es|is)?(\'+|\,+)?(\d)?\s?)*$/gm
+  lilyNoteMulti: /^(([abcdefg])(es|is)?(\'+|\,+)?(\d)?\s?)*$/gm,
+  euclideanRhythm:/^([abcdefg])(es|is)?(\'+|\,+)?(\d)?\((\d+)\,(\d+)\)$/m
 }
 
 function midiMatch(str, handlerMidi, handlerFreq) {
@@ -33,6 +36,28 @@ function multipleLily(str, handler) {
       }
       return prev
     }, [])
+    command = `playMultipleMidiNum(${notesList.length})`
+    handler(notesList)
+  }
+  return command
+}
+
+// <lilyNote>(int,int)
+function euclideanLily(str, handler){
+  let command
+  const euclideanMatch = str.match(regex.euclideanRhythm)
+  if (euclideanMatch) {
+    // pattern matching
+    const [_, note, modifier, octave, duration, k, n] = euclideanMatch
+    console.log(euclideanMatch)
+    const event = { note, modifier, octave, duration }
+    // TODO: Corregir la implementación del silencio/rest
+    // const rest = { duration }
+    const rest = { note:"r", modifier, octave, duration }
+    const pattern = bjorklund.euclideanPattern(Number(k),Number(n))
+    const notesList = pattern.map((x) => {
+      if (x === 1) {return event} else { return rest }
+    })
     command = `playMultipleMidiNum(${notesList.length})`
     handler(notesList)
   }
@@ -76,6 +101,7 @@ function sampleMatch(str, handler) {
 module.exports = {
   midiMatch,
   multipleLily,
+  euclideanLily,
   stopMatch,
   bpmMatch,
   sampleMatch

--- a/src/traducciones/sptm-live/parser.js
+++ b/src/traducciones/sptm-live/parser.js
@@ -26,6 +26,9 @@ class Parser {
     // Multiple lilypond note
     command =
       command || checks.multipleLily(str, this.state.handlerLilyMultiple)
+    // Euclidean lilypond note pattern
+    command =
+      command || checks.euclideanLily(str, this.state.handlerLilyMultiple)
     // Multiple lilypond note
     command = command || checks.stopMatch(str, this.state.handlerStop)
     // change BPM

--- a/src/traducciones/sptm-live/utils.js
+++ b/src/traducciones/sptm-live/utils.js
@@ -24,6 +24,8 @@ const letterToNote = (letter) => {
     case 'g':
       note = 7
       break
+    case 'r':
+      note = -40
     default:
       break
   }

--- a/static/js/bjorklund.js
+++ b/static/js/bjorklund.js
@@ -34,44 +34,36 @@ function zip(xs, ys) {
   }
 }
 
-// Con `append` como primer argumento juntamos mantenemos las listas
+
+const append = (xs, ys) => xs.concat(ys);
+
+// Con `append` como primer argumento, esta función nos permite juntar las listas
 // en un sólo nivel de arrays anidados
 function zipWith (f, xs, ys) {
   return zip(xs, ys).map(([x,y]) => f(x,y)); // pegado con la función
 }
 
-// Función auxiliar para complementar a zipWith
-const append = (xs, ys) => xs.concat(ys);
-
-// Prueba. Arrays correspondientes al ritmo (3,8)
+// Ejemplo: Arrays correspondientes al ritmo (3,8)
 let front = Array(3).fill([1]);
 let back = Array(5).fill([0]);
-console.log('front', front);
-console.log('back', back);
-
-// Prueba
-console.log('zip(front, back)', zip(front, back));
-console.log('zipWith(append, front, back)', zipWith(append, front, back));
+console.log(front); // [ [1], [1], [1] ]
+console.log(back); // [ [0], [0], [0], [0], [0] ]
+console.log(zip(front, back)); // [ [[1], [0]], [[1], [0]], [[1], [0]] ]
+console.log(zipWith(append, front, back)); // [ [1,0], [1,0], [1,0] ]
 
 // Algoritmo de Bjorklund
 function bjorklund(front, back) {
   if (back.length > 1) {
-    const newFront = zipWith(append, front, back) // front.map((f, i) => f.concat(back[i]));
+    const newFront = zipWith(append, front, back)
     const newBack = diffList(front, back);
-    console.log('newFront', newFront); // debug
-    console.log('newBack', newBack); // debug
     return bjorklund(newFront, newBack);
   } else {
-    console.log('---exit Bjorklund---'); // debug
     return front.concat(back);
   }
 }
 
-// Prueba
-console.log('bjorklund(front, back)', bjorklund(front,back));
-console.log('bjorklund(back, front)', bjorklund(front,back));
-
-
+// Continua ejemplo:
+console.log(bjorklund(front,back)); // [ [1,0,0], [1,0,0], [1,0] ]
 
 // Genera el patrón euclidiano
 function euclideanPattern(onsets, pulses) {
@@ -81,63 +73,7 @@ function euclideanPattern(onsets, pulses) {
   return bjorklundResult.flat();
 }
 
-console.log('euclideanPattern(3,8)', euclideanPattern(3,8));
+// Resultado:
+console.log(euclideanPattern(3,8)); // [ 1,0,0,1,0,0,1,0 ]
 
-// TODO: Comparar con la versión mkontogiannis/euclidean-rhythms
-// Para comparar estilos (mi investigación) y detectar posibles mejoras del código.
-
-/**
- *  Returns the calculated pattern of equally distributed pulses in total steps
- *  based on the euclidean rhythms algorithm described by Godfried Toussaint
- *
- *  @method  getPattern
- *  @param {Number} pulses Number of pulses in the pattern
- *  @param {Number} steps  Number of steps in the pattern (pattern length)
- */
-
-/* EMPIEZA EL CÓDIGO
-export function getPattern(pulses: number, steps: number) {
-  if (pulses < 0 || steps < 0 || steps < pulses) {
-    return [];
-  }
-
-  // Create the two arrays
-  let first = new Array(pulses).fill([1]);
-  let second = new Array(steps - pulses).fill([0]);
-
-  let firstLength = first.length;
-  let minLength = Math.min(firstLength, second.length);
-
-  let loopThreshold = 0;
-  // Loop until at least one array has length gt 2 (1 for first loop)
-  while (minLength > loopThreshold) {
-    // Allow only loopThreshold to be zero on the first loop
-    if (loopThreshold === 0) {
-      loopThreshold = 1;
-    }
-
-    // For the minimum array loop and concat
-    for (let x = 0; x < minLength; x++) {
-      first[x] = [...first[x], ...second[x]];
-    }
-
-    // if the second was the bigger array, slice the remaining elements/arrays and update
-    if (minLength === firstLength) {
-      second = second.slice(minLength);
-    }
-    // Otherwise update the second (smallest array) with the remainders of the first
-    // and update the first array to include only the extended sub-arrays
-    else {
-      second = first.slice(minLength);
-      first = first.slice(0, minLength);
-    }
-    firstLength = first.length;
-    minLength = Math.min(firstLength, second.length);
-  }
-
-  // Build the final array
-  const pattern: number[] = [...first.flat(), ...second.flat()];
-
-  return pattern;
-}
-*/
+module.exports = { euclideanPattern }

--- a/static/js/bjorklund.js
+++ b/static/js/bjorklund.js
@@ -2,9 +2,10 @@
 
 //FUNCIONES AUXILIARES
 
-// Calcula la duración de cada pulso, en microsegundos, en un ritmo euclidiano.
+// Calcula la duración de cada pulso (isócrono) en microsegundos
+// a partir de los ciclos por segundo y el número de pulsos.
 function eventDurationMs(cps, pulses) {
-  let milliSecondsPerCycle = (1 / cps) * 10 ** 6;
+  let milliSecondsPerCycle = (1 / cps) * (10 ** 6);
   let cyclePartition = pulses;
   return Math.round(milliSecondsPerCycle / cyclePartition);
 }
@@ -21,7 +22,7 @@ function diffList(xs, ys) {
 }
 
 // Funciones de orden superior para combinar dos Arrays
-// Simulan el funcionamento de las correspondientes funciones en Haskell.
+// Simulan el funcionamento de las correspondientes funciones en Haskell
 
 function zip(xs, ys) {
   let lx = xs.length;
@@ -43,13 +44,15 @@ function zipWith (f, xs, ys) {
   return zip(xs, ys).map(([x,y]) => f(x,y)); // pegado con la función
 }
 
-// Ejemplo: Arrays correspondientes al ritmo (3,8)
-let front = Array(3).fill([1]);
-let back = Array(5).fill([0]);
-console.log(front); // [ [1], [1], [1] ]
-console.log(back); // [ [0], [0], [0], [0], [0] ]
-console.log(zip(front, back)); // [ [[1], [0]], [[1], [0]], [[1], [0]] ]
-console.log(zipWith(append, front, back)); // [ [1,0], [1,0], [1,0] ]
+//////////////////////////////////////////////////////////////////////////////
+// // Ejemplo: Arrays correspondientes al ritmo (3,8)                       //
+// const front = Array(3).fill([1]);                                        //
+// const back = Array(5).fill([0]);                                         //
+// console.log(front); // [ [1], [1], [1] ]                                 //
+// console.log(back); // [ [0], [0], [0], [0], [0] ]                        //
+// console.log(zip(front, back)); // [ [[1],[0]], [[1],[0]], [[1],[0]] ] //
+// console.log(zipWith(append, front, back)); // [ [1,0], [1,0], [1,0] ]    //
+//////////////////////////////////////////////////////////////////////////////
 
 // Algoritmo de Bjorklund
 function bjorklund(front, back) {
@@ -62,10 +65,12 @@ function bjorklund(front, back) {
   }
 }
 
-// Continua ejemplo:
-console.log(bjorklund(front,back)); // [ [1,0,0], [1,0,0], [1,0] ]
+////////////////////////////////////////////////////////////////////////
+// // Continua ejemplo:                                               //
+// console.log(bjorklund(front,back)); // [ [1,0,0], [1,0,0], [1,0] ] //
+////////////////////////////////////////////////////////////////////////
 
-// Genera el patrón euclidiano
+// Generar patrón euclidiano
 function euclideanPattern(onsets, pulses) {
   const front = Array(onsets).fill([1]);
   const back = Array(pulses - onsets).fill([0]);
@@ -73,7 +78,9 @@ function euclideanPattern(onsets, pulses) {
   return bjorklundResult.flat();
 }
 
-// Resultado:
-console.log(euclideanPattern(3,8)); // [ 1,0,0,1,0,0,1,0 ]
+////////////////////////////////////////////////////////////////
+// // Resultado:                                              //
+// console.log(euclideanPattern(3,8)); // [ 1,0,0,1,0,0,1,0 ] //
+////////////////////////////////////////////////////////////////
 
 module.exports = { euclideanPattern }


### PR DESCRIPTION
Implementación de ritmos euclideanos en el editor.

* Añadí una regex para la notación euclideana. De momento sólo se puede escribir un ritmo euclidiano por linea de la forma `<lilyNote>(k,n)` para naturales positivos $k$ y $n$.
* Fue necesario convertir los argumentos para la función `euclideanPattern` (extraidos de la deconstrucción de la regex) a tipo numérico. Este error fue algo tedioso de detectar.
* Utilizo el mismo handler que `multipleLily`, pues `euclideanLily` produce a su vez una lista de notas lilypond.
* Luego habrá que revisar la implementación de rest. Por el momento permanece acomplada a las notas.

También reorganicé bjorklund.js, quitando contenido innecesario y comentando varios de los console.logs que servian de ejemplo para hacerlos parte de la documentación.

fixes #138 