### PR TITLE
Habilitar botones play y stop en Movil y Desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -128,7 +128,19 @@ header h1 {
 }
 
 .editorLV > button{
-  display: none;
+  display: flex;
+  margin: 20px auto;
+  display: inline-block;
+  outline: 0;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  border-radius: 4px;
+  font-size: 13px;
+  height: 30px;
+  background-color: #0000000d;
+  color: #0e0e10;
+  padding: 0 20px;
 }
 
 .acerca {
@@ -420,21 +432,6 @@ footer {
     order: -1;
   }
 
-  .editorLV > button{
-  display: flex;
-  margin: 5% auto;
-  display: inline-block;
-  outline: 0;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  border-radius: 4px;
-  font-size: 13px;
-  height: 30px;
-  background-color: #0000000d;
-  color: #0e0e10;
-  padding: 0 20px;
-  }
 }
 
 /* ######## */

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <h2 for="header_editor">Editor sencillo</h2>
         <div id="editor">
         </div>
-        <button type="button"  id="playLine" class="playLV">Play</button>
+        <button type="button" id="playLine">Play</button>
         <button type="button" id="detenerSeq" class="botones-sonido">Detener secuencia</button>
       </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -80,15 +80,14 @@
         <div>
           <input id="audio_file2" type="file" accept="audio/*" title="Cargar archivo" />
         </div>
-        <button type="button" id="detenerSeq" class="botones-sonido">Detener secuencia</button>
-        <button type="button" id="playLine" class="botones-sonido">></button>
         <!--Necesitamos poner por aquí una caja de texto para escribir el código para live codear-->
       </div>
       <div class="editorLV">
         <h2 for="header_editor">Editor sencillo</h2>
         <div id="editor">
         </div>
-        <button type="button" class="playLV">Play</button>
+        <button type="button"  id="playLine" class="playLV">Play</button>
+        <button type="button" id="detenerSeq" class="botones-sonido">Detener secuencia</button>
       </div>
   </section>
   <div class="separador"></div>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
           <input id="audio_file2" type="file" accept="audio/*" title="Cargar archivo" />
         </div>
         <button type="button" id="detenerSeq" class="botones-sonido">Detener secuencia</button>
+        <button type="button" id="playLine" class="botones-sonido">></button>
         <!--Necesitamos poner por aquí una caja de texto para escribir el código para live codear-->
       </div>
       <div class="editorLV">

--- a/src/editorCodeMirror/editorParser.js
+++ b/src/editorCodeMirror/editorParser.js
@@ -41,7 +41,7 @@ function EditorParser({ parent, parser, handlePlay }) {
       language.of(javascript()),
       EditorView.lineWrapping,
       EditorView.updateListener.of((v) => {
-        currentLineText = getCurrentLineText(view)
+        currentLineText = getCurrentLineText(v)
       })
     ]
   })

--- a/src/editorCodeMirror/editorParser.js
+++ b/src/editorCodeMirror/editorParser.js
@@ -5,13 +5,27 @@ import { javascript } from '@codemirror/lang-javascript'
 import { keymap } from '@codemirror/view'
 import { tutorialString } from './tutorialString'
 
-function EditorParser({ parent, parser }) {
+function getCurrentLineText(view) {
+  const currentLine = view.state.doc.lineAt(
+    view.state.selection.main.head
+  ).number
+  const cursorText = view.state.doc.text[currentLine - 1]
+  return cursorText
+}
 
+function EditorParser({ parent, parser, handlePlay }) {
   const keymaps = []
+  let currentLineText = ''
   keymaps.push(
     keymap.of({
       key: 'Ctrl-Enter',
       run: () => this.evaluar(),
+      preventDefault: true
+    }),
+
+    keymap.of({
+      key: 'Ctrl-.',
+      run: () => this.stopAll(),
       preventDefault: true
     })
   )
@@ -25,20 +39,34 @@ function EditorParser({ parent, parser }) {
       keymaps,
       basicSetup,
       language.of(javascript()),
-      EditorView.lineWrapping
+      EditorView.lineWrapping,
+      EditorView.updateListener.of((v) => {
+        currentLineText = getCurrentLineText(view)
+      })
     ]
   })
 
   let view = new EditorView({ state: startState, parent })
 
   this.evaluar = function () {
-    const currentLine = view.state.doc.lineAt(
-      view.state.selection.main.head
-    ).number
-    const cursorText = view.state.doc.text[currentLine - 1]
-    parser.parseString(cursorText)
+    parser.parseString(getCurrentLineText(view))
+
     return true
   }
+  this.stopAll = function () {
+    stopLine()
+  }
+
+  function playCurrentLine() {
+    parser.parseString(getCurrentLineText(view))
+  }
+
+  function stopLine() {
+    console.log('STOP ALL')
+    parser.parseString('.')
+  }
+
+  return { view, playCurrentLine, stopLine }
 }
 
 module.exports = { EditorParser }

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -11,9 +11,7 @@ c4(3,8)
 g8(5,12)
 
 // El punto detiene la ultima secuencia reproducida
-.
-
-`
+.`
 
 module.exports = {
   tutorialString

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -13,14 +13,7 @@ g8(5,12)
 // El punto detiene la ultima secuencia reproducida
 .
 
-// Falta implementar los siguientes
-c
-cis
-cis2
-ces,8
-#samp 1|2
-#samp
-120bpm`
+`
 
 module.exports = {
   tutorialString

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,15 @@
 import { EditorParser } from './editorCodeMirror/editorParser'
 import { SPTMController } from './sptm-live/SPTMController'
 
+let parent = document.querySelector('#editor')
+let stopSoundObj = document.querySelector('#detenerSeq')
+let playLineObj = document.querySelector('#playLine')
+
 var AudioContext = window.AudioContext || window.webkitAudioContext
 const audioCtx = new AudioContext()
 
 let { parser } = SPTMController(audioCtx)
+let { playCurrentLine, stopLine } = new EditorParser({ parent, parser })
 
-let parent = document.querySelector('#editor')
-let editor = new EditorParser({ parent, parser })
+stopSoundObj.addEventListener('click', () => stopLine())
+playLineObj.addEventListener('click', () => playCurrentLine())


### PR DESCRIPTION
# Botones play y stop

Implementar las funciones para que los botones play y stop para que se pueda usar en tableta y celular y se conecten con el motor de audio
<img width="433" alt="image" src="https://github.com/sptm-unam/seminario-app/assets/9595617/f3b359e5-2668-4711-af4b-1446a2fa428f">

- Cambie el CSS para que el play y stop se vean siempre en caso de que un usuario con tableta de alta resolucion o en computadora con pantalla tactil necesiten usar el boton.
- Play reproduce la linea seleccionada actual
- Detener, detiene la ultima linea reproducida.
- En escritorio Ctrl+. detiene la ultima linea reproducida (como en SuperCollider, pero no detiene todo, solo la ultima)

Pueden probarlo aqui:
https://holomorfo.github.io/seminario-app-publico/