### PR TITLE
Implement synth change 

### DIFF
--- a/src/SoundEnvironment/Sine.js
+++ b/src/SoundEnvironment/Sine.js
@@ -6,10 +6,8 @@ class Sine {
     this.gainNode = this.audioCtx.createGain()
     this.oscillator.type = type
     this.oscillator.connect(this.gainNode)
-
     this.gainNode.connect(this.audioCtx.destination)
     this.gainNode.gain.setValueAtTime(1, this.audioCtx.currentTime)
-
     this.gainNode.connect(this.audioCtx.destination)
   }
 

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -1,4 +1,4 @@
-const tutorialString = `// Presiona ctrl+enter para correr la linea donde esta el cursor o la seleccion de texto
+const tutorialString = `// Presiona ctrl+enter para correr la linea del cursor o la seleccion
 // Ritmos euclidianos
 c4(3,8)
 g8(5,12)
@@ -6,7 +6,6 @@ g8(5,12)
 // Notacion live lily
 g2 b2
 c3 a3 e3
-c a e
 a2 b2 e2 g2
 a4 b4 c4 d4 e4
 
@@ -16,6 +15,13 @@ square
 a3 b3 c3
 sawtooth
 g4 d4 a4
+
+// Tocar secuencia con elegir sintethizador
+sawtooth c3 a3 e3
+triangle a3 g3 b3  
+sine a3 g3 b3  
+square f3 b3 a3  
+
 // Implementado nota simple midi
 60
 // Implementado frequencia simple

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -10,6 +10,12 @@ c a e
 a2 b2 e2 g2
 a4 b4 c4 d4 e4
 
+// Cambiar el oscilador de la siguiente secuencia
+// sine, triangle, sawtooth, square
+square
+a3 b3 c3
+sawtooth
+g4 d4 a4
 // Implementado nota simple midi
 60
 // Implementado frequencia simple

--- a/src/sptm-live/AudioEngine.js
+++ b/src/sptm-live/AudioEngine.js
@@ -35,7 +35,7 @@ const AudioEngine = function (audioContext) {
     hashNodes[id] = element
     stackNodes.push(id)
   }
-  
+
   function stopAndRemoveLast() {
     if (stackNodes.length > 0) {
       const idPop = stackNodes.pop()
@@ -50,7 +50,7 @@ const AudioEngine = function (audioContext) {
     playMidi: function (midiNum) {
       // Check current oscilator in state
       // create oscilator with current kind
-      const osc = new Sine(audioContext)
+      const osc = new Sine(audioContext, state.synth)
       osc.gain(state.gain)
       // set frequency with midi num
       const freq = midiToFrequency(parseInt(midiNum))
@@ -64,7 +64,7 @@ const AudioEngine = function (audioContext) {
       printState()
     },
     playFreq: function (freqStr) {
-      const osc = new Sine(audioContext)
+      const osc = new Sine(audioContext, state.synth)
       osc.gain(state.gain)
       const freq = parseInt(freqStr)
       osc.playDuration(freq, parseInt(state.duration))
@@ -77,7 +77,7 @@ const AudioEngine = function (audioContext) {
     },
     playLilyMultiple: function (notesList) {
       console.table(notesList)
-      const osc = new Sine(audioContext)
+      const osc = new Sine(audioContext, state.synth)
       const freqList = notesList.map((e) =>
         midiToFrequency(60 + letterToNote(e.note))
       )
@@ -100,25 +100,17 @@ const AudioEngine = function (audioContext) {
     samplePlay: function () {
       alert('sample engine')
     },
-    
-      smplsq: function(seq) {
-	  
-	  const audioFile1 = document.getElementById('audio_file1');
-	  
-	  // console.log("smplsq");
-
-	  const smpl = new Player(audioContext, audioFile1)
-	  // smpl.load(audioFile1); 
-	  smpl.sequence(seq);
-	  // smpl.gain(0.5); // state es el estado inicial?
-	  // smpl.startSeq();
-	  // smpl.start(0);
-	  // smpl.startSeq(); 
-	  addElementToEngine(smpl);
-	  printState(); 
-      }
-
-      
+    smplsq: function (seq) {
+      const audioFile1 = document.getElementById('audio_file1')
+      const smpl = new Player(audioContext, audioFile1)
+      smpl.sequence(seq)
+      addElementToEngine(smpl)
+      printState()
+    },
+    synthChange: function (type) {
+      state.synth = type
+      console.log(state)
+    }
   }
 }
 

--- a/src/sptm-live/AudioEngine.js
+++ b/src/sptm-live/AudioEngine.js
@@ -75,9 +75,9 @@ const AudioEngine = function (audioContext) {
       addElementToEngine(osc)
       printState()
     },
-    playLilyMultiple: function (notesList) {
+    playLilyMultiple: function (synth, notesList) {
       console.table(notesList)
-      const osc = new Sine(audioContext, state.synth)
+      const osc = new Sine(audioContext, synth || state.synth)
       const freqList = notesList.map((e) =>
         midiToFrequency(60 + letterToNote(e.note))
       )

--- a/src/sptm-live/SPTMController.js
+++ b/src/sptm-live/SPTMController.js
@@ -10,7 +10,8 @@ const SPTMController = function (audioContext) {
     handlerStop: engine.stopAll,
     handlerBpm: engine.changeBPM,
     handlerSamplePlay: engine.samplePlay,
-    handlerSmplsq: engine.smplsq  
+    handlerSmplsq: engine.smplsq,
+    handlerSynthChange: engine.synthChange
   }
   const parser = new Parser(handlers)
   return {

--- a/src/sptm-live/conditionsCheck.js
+++ b/src/sptm-live/conditionsCheck.js
@@ -3,7 +3,11 @@ const bjorklund = require('../patrones/bjorklund')
 const regex = {
   lilyNote: /^([rabcdefg])(es|is)?(\'+|\,+)?(\d)?$/m,
   lilyNoteMulti: /^(([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\s?)*$/gm,
-  euclideanRhythm: /^([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\((\d+)\,(\d+)\)$/m
+  euclideanRhythm: /^([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\((\d+)\,(\d+)\)$/m,
+
+  synthSelect: /^(sine|square|sawtooth|triangle)$/m,
+  smplsqMatch:
+    /smplsq\s((?:\d+(?:\.\d*)?|\.\d+)(?:\s(?:\d+(?:\.\d*)?|\.\d+))*)$/
 }
 
 function midiMatch(str, handlerMidi, handlerFreq) {
@@ -104,19 +108,26 @@ function sampleMatch(str, handler) {
 
 function smplsqMatch(str, handler) {
   let command
-  let smpl = str.match(
-    /smplsq\s((?:\d+(?:\.\d*)?|\.\d+)(?:\s(?:\d+(?:\.\d*)?|\.\d+))*)$/
-  )
+  let smpl = str.match(regex.smplsqMatch)
   let sq = []
   if (smpl) {
     sq = smpl[1].split(' ')
-    console.log('si cuadra la seq')
-    // console.log(smpl[1].split(' '));
     handler(sq)
-  } else {
-    console.log('no cuadra la seq')
+    command = `smplsq(${sq})`
   }
-  command = `smplsq(${sq})`
+  return command
+}
+
+function synthMatch(str, handler) {
+  let command
+  // change BPM
+  let synthMatch = str.match(regex.synthSelect)
+  console.log('test synth')
+  if (synthMatch) {
+    console.log(synthMatch)
+    command = `synthChange(${synthMatch[1]})`
+    handler(synthMatch[1])
+  }
   return command
 }
 
@@ -127,5 +138,6 @@ module.exports = {
   stopMatch,
   bpmMatch,
   sampleMatch,
-  smplsqMatch
+  smplsqMatch,
+  synthMatch
 }

--- a/src/sptm-live/conditionsCheck.js
+++ b/src/sptm-live/conditionsCheck.js
@@ -2,7 +2,7 @@ const bjorklund = require('../patrones/bjorklund')
 
 const regex = {
   lilyNote: /^([rabcdefg])(es|is)?(\'+|\,+)?(\d)?$/m,
-  lilyNoteMulti: /^(([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\s?)*$/gm,
+  lilyNoteMulti: /^(sine|triangle|sawtooth|square)?\s?(([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\s?)+$/m,
   euclideanRhythm: /^([rabcdefg])(es|is)?(\'+|\,+)?(\d)?\((\d+)\,(\d+)\)$/m,
 
   synthSelect: /^(sine|square|sawtooth|triangle)$/m,
@@ -32,6 +32,7 @@ function multipleLily(str, handler) {
   // Multiple lilypond note
   let lilyMelodyMatch = str.match(regex.lilyNoteMulti)
   if (lilyMelodyMatch) {
+    const [_, synth] = lilyMelodyMatch
     const notesList = str.split(' ').reduce((prev, current) => {
       let lilyOctaveUp = current.match(regex.lilyNote)
       if (lilyOctaveUp) {
@@ -41,7 +42,7 @@ function multipleLily(str, handler) {
       return prev
     }, [])
     command = `playMultipleMidiNum(${notesList.length})`
-    handler(notesList)
+    handler(synth,notesList)
   }
   return command
 }
@@ -67,7 +68,7 @@ function euclideanLily(str, handler) {
       }
     })
     command = `playMultipleMidiNum(${notesList.length})`
-    handler(notesList)
+    handler('sine',notesList)// el primer elemento es el synte, TODO implementar parsing
   }
   return command
 }

--- a/src/sptm-live/parser.js
+++ b/src/sptm-live/parser.js
@@ -10,6 +10,7 @@ Handlers expected
   handlerBpm,
   handlerSamplePlay,
   handlerSmplsq 
+  handlerSynthChange
 */
 
 class Parser {
@@ -39,6 +40,8 @@ class Parser {
     command = command || checks.sampleMatch(str, this.state.handlerSamplePlay)
     // smplsq
     command = command || checks.smplsqMatch(str, this.state.handlerSmplsq)
+    // synth change
+    command = command || checks.synthMatch(str, this.state.handlerSynthChange)
     return command
   }
 }


### PR DESCRIPTION
# Cambio de sintetizador en live lily

> Fixes #166 

Puede probarse en:
https://holomorfo.github.io/seminario-app-publico/#sonido

En este PR se implementa el cambio de sintetizador para la siguiente secuencia, si el usuario envia el comando "sine", "triangle", "sawtooth" o "square" la siguiente sequencia utilizara ese sintetizador

![image](https://github.com/sptm-unam/seminario-app/assets/9595617/07fa7568-2b0b-4a3f-9c27-4955ee012b3f)
