### PR TITLE
Octavas y duraciones relativas live lily

### DIFF
--- a/src/editorCodeMirror/editorParser.js
+++ b/src/editorCodeMirror/editorParser.js
@@ -9,8 +9,11 @@ function getCurrentLineText(view) {
   const currentLine = view.state.doc.lineAt(
     view.state.selection.main.head
   ).number
-  const cursorText = view.state.doc.text[currentLine - 1]
-  return cursorText
+  if (view.state.doc.text) {
+    return view.state.doc.text[currentLine - 1]
+  } else {
+    return ''
+  }
 }
 
 function EditorParser({ parent, parser, handlePlay }) {
@@ -38,7 +41,6 @@ function EditorParser({ parent, parser, handlePlay }) {
     extensions: [
       keymaps,
       basicSetup,
-      language.of(javascript()),
       EditorView.lineWrapping,
       EditorView.updateListener.of((v) => {
         currentLineText = getCurrentLineText(v)

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -4,13 +4,13 @@ c4(3,8)
 g8(5,12)
 // Presiona ctrl+. para detener la última secuencia
 // Notacion live lily
-g2 b2
-c3 a3 e3
-a2 b2 e2 g2
-a4 b4 c4 d4 e4
+g2 b
+c3 a e
+a4 b e g
+a4 b c d e
 a'' b,,, c'''
 c d e f g' a b c'
-c d e f g a b c' d e f g a b c'
+c d8 e f g a3 b c'2 d e f8 g a b c'
 // Cambiar el oscilador de la siguiente secuencia
 // sine, triangle, sawtooth, square
 square
@@ -29,7 +29,7 @@ square f3 b3 a3
 // Implementado frequencia simple
 440
 // El punto detiene la ultima secuencia reproducida
-.`
+. `
 
 module.exports = {
   tutorialString

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -10,7 +10,7 @@ a2 b2 e2 g2
 a4 b4 c4 d4 e4
 a'' b,,, c'''
 c d e f g' a b c'
-c d e f g a b c' d e f g a b c''
+c d e f g a b c' d e f g a b c'
 // Cambiar el oscilador de la siguiente secuencia
 // sine, triangle, sawtooth, square
 square

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -8,7 +8,9 @@ g2 b2
 c3 a3 e3
 a2 b2 e2 g2
 a4 b4 c4 d4 e4
-
+a'' b,,, c'''
+c d e f g' a b c'
+c d e f g a b c' d e f g a b c''
 // Cambiar el oscilador de la siguiente secuencia
 // sine, triangle, sawtooth, square
 square

--- a/src/sptm-live/AudioEngine.js
+++ b/src/sptm-live/AudioEngine.js
@@ -5,14 +5,15 @@ const {
   midiToFrequency,
   letterToNote,
   durationToTime,
-  createTimeId
+  createTimeId,
+  calculateOctave
 } = require('./utils')
 
 const AudioEngine = function (audioContext) {
   console.log('audio engine')
 
   const state = {
-    synth: 'sin',
+    synth: 'sine',
     duration: '1',
     octave: '2',
     bpm: '60',
@@ -76,14 +77,17 @@ const AudioEngine = function (audioContext) {
       printState()
     },
     playLilyMultiple: function (synth, notesList) {
-      console.table(notesList)
       const osc = new Sine(audioContext, synth || state.synth)
-      const freqList = notesList.map((e) =>
-        midiToFrequency(60 + letterToNote(e.note))
-      )
-      const durationList = notesList.map((e) => durationToTime(e.duration))
-      console.log({ freqList })
-      console.log({ durationList })
+      const freqList = []
+      const durationList = []
+      let octaveNum = 0
+      for (let index = 0; index < notesList.length; index++) {
+        const { note, octave, duration } = notesList[index]
+        octaveNum += calculateOctave(octave)
+        const freq = midiToFrequency(12 * (octaveNum + 5) + letterToNote(note))
+        freqList.push(freq)
+        durationList.push(durationToTime(duration))
+      }
       osc.playList(freqList, durationList)
       osc.gain(state.gain)
       state.lastOsc = osc

--- a/src/sptm-live/AudioEngine.js
+++ b/src/sptm-live/AudioEngine.js
@@ -81,12 +81,14 @@ const AudioEngine = function (audioContext) {
       const freqList = []
       const durationList = []
       let octaveNum = 0
+      let currentDuration = 1
       for (let index = 0; index < notesList.length; index++) {
         const { note, octave, duration } = notesList[index]
         octaveNum += calculateOctave(octave)
         const freq = midiToFrequency(12 * (octaveNum + 5) + letterToNote(note))
         freqList.push(freq)
-        durationList.push(durationToTime(duration))
+        currentDuration = duration || currentDuration
+        durationList.push(durationToTime(currentDuration))
       }
       osc.playList(freqList, durationList)
       osc.gain(state.gain)

--- a/src/sptm-live/conditionsCheck.js
+++ b/src/sptm-live/conditionsCheck.js
@@ -14,9 +14,7 @@ function midiMatch(str, handlerMidi, handlerFreq) {
   let command = ''
   let midiMatch = str.match(/^(\d{1,5})$/gm)
   if (midiMatch) {
-    console.log('midi match')
     if (parseFloat(midiMatch[0]) < 128) {
-      console.log('parser midi')
       command = `playMidi(${midiMatch[0]})`
       handlerMidi(midiMatch[0])
     } else {

--- a/src/sptm-live/test/conditionsCheck.test.js
+++ b/src/sptm-live/test/conditionsCheck.test.js
@@ -23,37 +23,39 @@ describe('Checky Lily match', () => {
     const expectObj = [{ note: 'c' }]
     const handlerLily = jest.fn()
     checks.multipleLily('c', handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call lily handler if passed simple lily note with modifier', () => {
     const expectObj = [{ note: 'c', modifier: 'is' }]
     const handlerLily = jest.fn()
     checks.multipleLily('cis', handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call lily handler if passed simple lily note with modifier "is" and octave up', () => {
     const expectObj = [{ note: 'c', modifier: 'is', octave: "'" }]
     const handlerLily = jest.fn()
     checks.multipleLily("cis'", handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call lily handler if passed simple lily note with modifier "is" and two octave up', () => {
     const expectObj = [{ note: 'c', modifier: 'is', octave: "''" }]
     const handlerLily = jest.fn()
     checks.multipleLily("cis''", handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call lily handler if passed simple lily note without modifier "is" and octave up', () => {
     const expectObj = [{ note: 'c', octave: "''" }]
     const handlerLily = jest.fn()
     checks.multipleLily("c''", handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call lily handler if passed simple lily note with modifier "is", octave up and duration', () => {
-    const expectObj = [{ note: 'c', modifier: 'is', octave: "'", duration: '8' }]
+    const expectObj = [
+      { note: 'c', modifier: 'is', octave: "'", duration: '8' }
+    ]
     const handlerLily = jest.fn()
     checks.multipleLily("cis'8", handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
 })
 
@@ -88,7 +90,7 @@ describe('Checky Multiple Lily match', () => {
     ]
     const handlerLily = jest.fn()
     checks.multipleLily('c a b d g', handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
   it('should call multiplelily handler if passed simple lily notes list modifiers, octave and durations', () => {
     const expectObj = [
@@ -100,7 +102,7 @@ describe('Checky Multiple Lily match', () => {
     ]
     const handlerLily = jest.fn()
     checks.multipleLily("cis aes'' b,8 d' g4", handlerLily)
-    expect(handlerLily).toHaveBeenCalledWith(expectObj)
+    expect(handlerLily).toHaveBeenCalledWith(undefined, expectObj)
   })
 })
 
@@ -121,10 +123,26 @@ describe('Check BPM match', () => {
 })
 
 describe('Check sample play match', () => {
-  it('should call sample play handler if strin is in format #sample 2|2', () => {
+  it('should call sample play handler if string is in format #sample 2|2', () => {
     const expected = { duration: '2', rate: '2', sample: 'sample' }
     const handlerBPM = jest.fn()
     checks.sampleMatch('#sample 2|2', handlerBPM)
     expect(handlerBPM).toHaveBeenCalledWith(expected)
   })
+})
+
+describe('Check euclidean lily play match', () => {
+  it.todo(
+    'should call euclidean play handler if strin is in format lilyNote(num,num)'
+  )
+  // const expectObj = [
+  //   { duration: undefined, modifier: 'is', note: 'c', octave: undefined },
+  //   { duration: undefined, modifier: 'es', note: 'a', octave: "''" },
+  //   { duration: '8', modifier: undefined, note: 'b', octave: ',' },
+  //   { duration: undefined, modifier: undefined, note: 'd', octave: "'" },
+  //   { duration: '4', modifier: undefined, note: 'g', octave: undefined }
+  // ]
+  // const handlerEuclidean = jest.fn()
+  // checks.euclideanLily('c8(3,5)', handlerEuclidean)
+  // expect(handlerEuclidean).toHaveBeenCalledWith('sine', expectObj)
 })

--- a/src/sptm-live/test/parser.test.js
+++ b/src/sptm-live/test/parser.test.js
@@ -5,6 +5,11 @@ it('should instanciate parser', () => {
   expect(parser).toBeDefined()
 })
 
+it('should parse a empty string and no nothing', () => {
+  const parser = new Parser()
+  expect(parser.parseString('')).toBe(undefined)
+})
+
 it('should parse a stop string', () => {
   // Arrange
   const handlers = {
@@ -43,7 +48,7 @@ it('should parse a lily string', () => {
   expect(handlers.handlerLilyMultiple).toHaveBeenCalled()
 })
 
-it.only('should parse a sample sinlge string', () => {
+it('should parse a sample sinlge string', () => {
   // Arrange
   const handlers = {
     handlerMidi: jest.fn(),

--- a/src/sptm-live/test/utils.test.js
+++ b/src/sptm-live/test/utils.test.js
@@ -10,11 +10,41 @@ test('Debe regresar una frecuencia si se introduce un numero midi', () => {
 })
 
 
-it('letterToNote should return 9 if letter is a', () => {
-    // Arrange
-    const letter = 'a'
-    // Act
-    const note = utils.letterToNote(letter)
-    // Assert
-    expect(note).toBe(9)
+it('letterToNote should return corresponding numbre to letter ', () => {
+    expect(utils.letterToNote('a')).toBe(9)
+    expect(utils.letterToNote('b')).toBe(10)
+    expect(utils.letterToNote('c')).toBe(0)
+    expect(utils.letterToNote('d')).toBe(2)
+    expect(utils.letterToNote('e')).toBe(4)
+    expect(utils.letterToNote('f')).toBe(5)
+    expect(utils.letterToNote('g')).toBe(7)
+    expect(utils.letterToNote('la')).toBe(9)
+    expect(utils.letterToNote('si')).toBe(10)
+    expect(utils.letterToNote('do')).toBe(0)
+    expect(utils.letterToNote('re')).toBe(2)
+    expect(utils.letterToNote('mi')).toBe(4)
+    expect(utils.letterToNote('fa')).toBe(5)
+    expect(utils.letterToNote('sol')).toBe(7)
+    expect(utils.letterToNote('r')).toBe(-40)
+})
+
+test('modifierToNumeric should map is to +1 and es to -1', () => {
+    expect(utils.modifierToNumeric('is')).toBe(1)
+    expect(utils.modifierToNumeric('es')).toBe(-1)
+    expect(utils.modifierToNumeric('')).toBe(0)
+})
+
+test('calculateOctave should sum the number of apostrophes as +1 and commma to -1', () => {
+    expect(utils.calculateOctave('')).toBe(0)
+    expect(utils.calculateOctave("'")).toBe(1)
+    expect(utils.calculateOctave("''")).toBe(2)
+    expect(utils.calculateOctave(',')).toBe(-1)
+    expect(utils.calculateOctave(',,')).toBe(-2)
+})
+
+test('durationToTime should reutn the reciprocal of the value', () => {
+    expect(utils.durationToTime('2')).toBe(1/2)
+    expect(utils.durationToTime('')).toBe(NaN)
+    expect(utils.durationToTime('0')).toBe(Infinity)
+
 })

--- a/src/sptm-live/utils.js
+++ b/src/sptm-live/utils.js
@@ -24,6 +24,27 @@ const letterToNote = (letter) => {
     case 'g':
       note = 7
       break
+    case 'la':
+      note = 9
+      break
+    case 'si':
+      note = 10
+      break
+    case 'do':
+      note = 0
+      break
+    case 're':
+      note = 2
+      break
+    case 'mi':
+      note = 4
+      break
+    case 'fa':
+      note = 5
+      break
+    case 'sol':
+      note = 7
+      break
     case 'r':
       note = -40
     default:
@@ -48,9 +69,9 @@ const modifierToNumeric = (modifier) => {
   return value
 }
 
-const calculateOctave = (octaveModifier) => {
-  const upOctave = octaveModifier.filter((e) => e === "'").length
-  const downOctave = octaveModifier.filter((e) => e === ',').length
+const calculateOctave = (octaveModifier = '') => {
+  const upOctave = octaveModifier.split('').filter((e) => e === "'").length
+  const downOctave = octaveModifier.split('').filter((e) => e === ',').length
   return upOctave - downOctave
 }
 

--- a/src/sptm-live/utils.js
+++ b/src/sptm-live/utils.js
@@ -54,7 +54,7 @@ const letterToNote = (letter) => {
 }
 
 const modifierToNumeric = (modifier) => {
-  const value = 0
+  let value = 0
   switch (modifier) {
     case 'is':
       value = 1
@@ -78,6 +78,7 @@ const calculateOctave = (octaveModifier = '') => {
 const durationToTime = (durationString = 1) => 1 / parseInt(durationString)
 
 const createTimeId = () => `${new Date().getTime()}`
+
 module.exports = {
   midiToFrequency,
   letterToNote,


### PR DESCRIPTION
# Octavas y duraciones relativas

- Las octavas ya son relativas en Live lily cada que se cambie con un modificador `a'` o `a,,` las siguientes notas de esa secuencia cambiaran a esa octava, de la misma forma que las octavas en lilypond con la opcion de relativas:

- Tambien ya estan impelementadas las duraciones relativas, por ejemplo para escribir octavos ya no se necesita escribir la duracion en cada nota
```
a b4 c d e f8 g a b c
```
 En la lista anterior `a` dura un pulso, despues de la `b4` las notas `c d e` tambien duran un cuarto, y las siguientes duran 8

https://lilypond.org/doc/v2.23/Documentation/notation/writing-pitches

- Agregar pruebas unitarias

Pruebas en este ambiente:
https://holomorfo.github.io/seminario-app-publico/

