### PR TITLE
Deshabilitar temporalmente reproducir la linea actual

### DIFF
--- a/src/editorCodeMirror/editorParser.js
+++ b/src/editorCodeMirror/editorParser.js
@@ -42,9 +42,11 @@ function EditorParser({ parent, parser, handlePlay }) {
       keymaps,
       basicSetup,
       EditorView.lineWrapping,
-      EditorView.updateListener.of((v) => {
-        currentLineText = getCurrentLineText(v)
-      })
+      // EditorView.updateListener.of((v) => {
+      //   console.log(v)
+      //   currentLineText = getCurrentLineText(v)
+      //   console.log(currentLineText)
+      // })
     ]
   })
 

--- a/src/editorCodeMirror/tutorialString.js
+++ b/src/editorCodeMirror/tutorialString.js
@@ -1,5 +1,5 @@
-const tutorialString = `// Presiona ctrl+enter para correr la linea del cursor o la seleccion
-// Ritmos euclidianos
+const tutorialString = `// Presiona ctrl+enter para correr la seleccion de texto
+// Ritmos euclidianos, de momento solo "sine"
 c4(3,8)
 g8(5,12)
 // Presiona ctrl+. para detener la última secuencia


### PR DESCRIPTION
Quitar de las instrucciones la instruccion para reproducir la linea actual, ya que hay un error cuando el usuario presiona enter para crear una linea nueva.